### PR TITLE
Use a reference to update DOM before react does

### DIFF
--- a/src/NumericInput.js
+++ b/src/NumericInput.js
@@ -49,6 +49,12 @@ export default class NumericInput extends PureComponent {
         this.props.onChange(e);
     }
 
+    componentWillUpdate(nProps, nState){
+        if (this.state.value.length - nState.value.length === 2) {
+            this.refs.barrierVal.value = '0' + nState.value;
+        }
+    }
+
     render() {
         const { className, step, min, max, valueList } = this.props;
         const { value } = this.state;
@@ -63,6 +69,7 @@ export default class NumericInput extends PureComponent {
                     step={step}
                     list="values"
                     onChange={this.onChange}
+                    ref="barrierVal"
                 />
                 <button className="btn-flat step-up" onClick={this.onStepUp}>+</button>
                 <datalist id="values">

--- a/src/NumericInput.js
+++ b/src/NumericInput.js
@@ -51,7 +51,7 @@ export default class NumericInput extends PureComponent {
 
     componentWillUpdate(nProps, nState){
         if (this.state.value.length - nState.value.length === 2) {
-            this.refs.barrierVal.value = '0' + nState.value;
+            this.refs.input.value = '0' + nState.value;
         }
     }
 
@@ -69,7 +69,7 @@ export default class NumericInput extends PureComponent {
                     step={step}
                     list="values"
                     onChange={this.onChange}
-                    ref="barrierVal"
+                    ref="input"
                 />
                 <button className="btn-flat step-up" onClick={this.onStepUp}>+</button>
                 <datalist id="values">

--- a/src/__tests__/NumericInput-test.js
+++ b/src/__tests__/NumericInput-test.js
@@ -12,7 +12,7 @@ describe('<NumericInput />', () => {
 
     it('clicking the up button changes the value', () => {
         const onButtonClick = sinon.spy();
-        const wrapper = shallow(<NumericInput onChange={onButtonClick} />);
+        const wrapper = shallow(<NumericInput onChange={onButtonClick} value={123.123} />);
         wrapper.find('.step-up').simulate('click');
         expect(onButtonClick).to.have.property('callCount', 1);
     });


### PR DESCRIPTION
Hi,

Attached contained few changes that should address our issue with numeric field as mentioned in the card here for your perusal. https://trello.com/c/WoBOp2q1/723-number-input-usability . The PR attempt to update the real DOM wen the numeric reach a decimal place before react does. Allowing react to update our state would result in react recognising that as a new state thereby jumping and pushing our cursor to the end. 
